### PR TITLE
fix: properly null intervals on stop/end/tab-hide (closes #4)

### DIFF
--- a/game.js
+++ b/game.js
@@ -410,6 +410,8 @@
     function stopGame() {
       clearInterval(gameInterval);
       clearInterval(timerInterval);
+      gameInterval = null;
+      timerInterval = null;
       ctx.clearRect(0, 0, canvas.width, canvas.height);
       stopButton.style.display = 'none';
       if (pauseButton) pauseButton.style.display = 'none';
@@ -923,6 +925,8 @@
 
       clearInterval(gameInterval);
       clearInterval(timerInterval);
+      gameInterval = null;
+      timerInterval = null;
       ctx.clearRect(0, 0, canvas.width, canvas.height);
       stopButton.style.display = 'none';
       if (pauseButton) pauseButton.style.display = 'none';
@@ -1045,8 +1049,9 @@
         isPaused = true;
         clearInterval(gameInterval);
         clearInterval(timerInterval);
+        gameInterval = null;
+        timerInterval = null;
         pauseOverlay.style.display = 'flex';
-      } else if (!document.hidden && isPaused && !endGameTriggered && gameControls.style.display !== 'flex') {
-        // Don't auto-resume; let user resume manually
       }
+      // On return, user resumes manually via the pause overlay button
     });


### PR DESCRIPTION
Fixes stale interval IDs after clearInterval calls. Previously gameInterval was cleared but not set to null, causing the visibilitychange handler to fire a false pause when the game was not running. Also nulls intervals in endGame() and in the visibilitychange pause branch itself. Closes #4