### PR TITLE
fix: iPhone touch controls - cat disappears on tap (closes #12)

### DIFF
--- a/game.js
+++ b/game.js
@@ -165,9 +165,13 @@
     addTouchEventHandler(stopButton, stopGame);
 
     canvas.addEventListener('click', jump);
+    // On mobile, the dedicated jump button handles jumping.
+    // Canvas touchstart should only trigger jump on non-mobile (e.g. touch-enabled laptops).
     canvas.addEventListener('touchstart', function (e) {
-      e.preventDefault();
-      jump();
+      if (!isMobile) {
+        e.preventDefault();
+        jump();
+      }
     }, { passive: false });
 
     document.addEventListener('keydown', function (event) {
@@ -190,7 +194,8 @@
     });
 
     document.addEventListener('touchmove', function (event) {
-      if (!isMobile) {
+      // On mobile, track finger position to move the cat (direct touch control)
+      if (isMobile) {
         const touch = event.touches[0];
         cat.x = touch.clientX - cat.width / 2;
         cat.x = Math.max(0, Math.min(cat.x, canvas.width - cat.width));


### PR DESCRIPTION
Two bugs fixed:\n1. Canvas  was calling  unconditionally — on iPhone, any touch on the canvas (even while using the control buttons) triggered a jump with extreme velocity, sending the cat off-screen for many seconds. Now canvas touchstart only fires jump on non-mobile devices.\n2.  condition was  (inverted) so finger-drag tracking was running on desktop but not on the actual mobile devices where it matters.\n\nCloses #12