### PR TITLE
feat: random placeholder nickname (closes #13)

### DIFF
--- a/game.js
+++ b/game.js
@@ -65,6 +65,16 @@
     });
     updatePersonalBestDisplay();
 
+    // Random placeholder nicknames — a new one each page load
+    const _nicknamePlaceholders = [
+      'BaguetteMaster', 'CroissantKing', 'PurrfectCatcher', 'BreadWinner',
+      'MiaoGourmet', 'FélixLeChat', 'BagitPro', 'CatNapper',
+      'BreadHunter', 'PawsOfFury', 'YeastBeast', 'WhiskerBaker',
+    ];
+    nicknameInput.placeholder = _nicknamePlaceholders[
+      Math.floor(Math.random() * _nicknamePlaceholders.length)
+    ];
+
     // Global game variables
     let score = 0;
     let stars = 0;


### PR DESCRIPTION
Each page load, the nickname input gets a fun random placeholder (BaguetteMaster, PawsOfFury, etc.). It disappears when the user types — standard HTML placeholder behaviour, no JS needed beyond setting the attribute. Closes #13