### PR TITLE
Add play again flow on game over screen

### DIFF
--- a/game.js
+++ b/game.js
@@ -75,6 +75,14 @@
       Math.floor(Math.random() * _nicknamePlaceholders.length)
     ];
 
+    // Allow pressing Enter in the nickname field to start the game quickly
+    nicknameInput.addEventListener('keydown', function (event) {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        startGame();
+      }
+    });
+
     // Clouds (declared here so resizeCanvas → initClouds can write to it immediately)
     let clouds = [];
 
@@ -981,8 +989,20 @@
         ${isNewRecord
           ? '<div class="new-record">🏅 New Personal Best!</div>'
           : (getPersonalBest(selectedDifficulty) > 0 ? `<div style="color:#888;font-size:13px;">Best: ${getPersonalBest(selectedDifficulty)}</div>` : '')}
+        <div style="margin-top:12px;">
+          <button id="playAgainButton" style="margin-top:4px;padding:8px 18px;border-radius:999px;border:none;background:#FF5722;color:white;font-weight:bold;cursor:pointer;">Play Again</button>
+        </div>
       `;
       endScoreSummary.style.display = 'block';
+
+      const playAgainButtonEl = document.getElementById('playAgainButton');
+      if (playAgainButtonEl) {
+        playAgainButtonEl.addEventListener('click', function () {
+          // Hide summary and immediately start a new round with the current nickname & difficulty
+          endScoreSummary.style.display = 'none';
+          startGame();
+        });
+      }
 
       const gameData = {
         event: 'Game Ended',


### PR DESCRIPTION
This PR implements the improvements described in #20.\n\n## Changes\n- Add a **Play Again** button inside the end score summary box.\n- Wire the button to hide the summary and immediately start a new round using the current nickname and selected difficulty.\n- Allow pressing **Enter** in the nickname field to quickly start the game from the main screen.\n\n## Notes\n- The existing start/stop and pause behavior remains unchanged.\n- The Play Again button is only visible after a round ends and the summary is shown.\n\nFixes #20.