### PR TITLE
Strengthen accessibility & onboarding (instructions, orientation, focus)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,4 +1,4 @@
-  <style>
+<style>
     * {
       box-sizing: border-box;
       -webkit-tap-highlight-color: transparent;
@@ -146,6 +146,30 @@
       margin-bottom: 10px;
       min-height: 20px;
       font-weight: bold;
+    }
+    #howToPlay {
+      background-color: rgba(255, 255, 255, 0.95);
+      border-radius: 12px;
+      padding: 12px 16px;
+      margin-bottom: 16px;
+      width: 100%;
+      max-width: 360px;
+      color: #333;
+      box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+    }
+    #howToPlay h2 {
+      font-size: 18px;
+      margin: 0 0 8px 0;
+      text-align: center;
+      color: #FF5722;
+    }
+    #howToPlay ul {
+      margin: 0;
+      padding-left: 18px;
+      font-size: 14px;
+    }
+    #howToPlay li + li {
+      margin-top: 4px;
     }
     #endScoreSummary {
       background: rgba(255,255,255,0.95);
@@ -420,6 +444,16 @@
       background-color: #fff8f0;
     }
     #orientationWarning {
+      position: fixed;
+      left: 50%;
+      bottom: 16px;
+      transform: translateX(-50%);
+      background: rgba(0, 0, 0, 0.75);
+      color: #fff;
+      padding: 8px 14px;
+      border-radius: 999px;
+      font-size: 14px;
+      z-index: 220;
       display: none;
     }
   </style>

--- a/game.js
+++ b/game.js
@@ -155,8 +155,13 @@
         cat.height = 90;
       }
 
-      if (orientationWarning && isMobile && window.innerHeight > window.innerWidth) {
-        orientationWarning.style.display = 'none';
+      if (orientationWarning && isMobile) {
+        // Show orientation guidance when device is in portrait, hide in landscape.
+        if (window.innerHeight > window.innerWidth) {
+          orientationWarning.style.display = 'block';
+        } else {
+          orientationWarning.style.display = 'none';
+        }
       }
     }
 
@@ -1077,10 +1082,6 @@
     /**********************************************
      * 14) Misc
      **********************************************/
-    document.addEventListener('touchmove', function (event) {
-      // Prevent pinch-zoom; guard against undefined (non-iOS browsers don't set scale)
-      if (event.scale && event.scale !== 1) event.preventDefault();
-    }, { passive: false });
 
     window.addEventListener('load', function () {
       resizeCanvas();

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, maximum-scale=1.0, user-scalable=no">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="mobile-web-app-capable" content="yes">
   <link rel="icon" type="image/x-icon" href="assets/apple-touch-icon.png">
@@ -20,14 +20,23 @@
 </head>
 <body class="start">
   <div id="gameControls">
-    <input type="text" id="nicknameInput" placeholder="Enter your nickname">
-    <div id="difficultySelector">
+    <input type="text" id="nicknameInput" placeholder="Enter your nickname" aria-label="Nickname" autocomplete="off">
+    <div id="difficultySelector" aria-label="Difficulty" role="group">
       <span id="difficultyLabel">Difficulty:</span>
       <button class="diffBtn active" data-diff="easy">🟢 Easy</button>
       <button class="diffBtn" data-diff="normal">🟡 Normal</button>
       <button class="diffBtn" data-diff="hard">🔴 Hard</button>
     </div>
     <div id="personalBest"></div>
+    <div id="howToPlay">
+      <h2>How to Play</h2>
+      <ul>
+        <li>Use the left / right arrows (or A / D) to move the cat.</li>
+        <li>Press the up arrow or spacebar to jump.</li>
+        <li>On mobile, use the on-screen buttons to move and jump.</li>
+        <li>Catch as many baguettes as you can before the time runs out!</li>
+      </ul>
+    </div>
     <button id="startButton">Start Game</button>
   </div>
 
@@ -54,12 +63,14 @@
 
   <!-- Mobile touch controls -->
   <div id="mobileControls">
-    <button id="leftButton" class="controlButton">←</button>
-    <button id="jumpButton" class="controlButton">↑</button>
-    <button id="rightButton" class="controlButton">→</button>
+    <button id="leftButton" class="controlButton" aria-label="Move left">←</button>
+    <button id="jumpButton" class="controlButton" aria-label="Jump">↑</button>
+    <button id="rightButton" class="controlButton" aria-label="Move right">→</button>
   </div>
 
-  <div id="orientationWarning" style="display: none;"></div>
+  <div id="orientationWarning" role="status" aria-live="polite" style="display: none;">
+    Rotate your device to landscape for the best experience.
+  </div>
 
   <audio id="catchSound" src="assets/sound.mp3"></audio>
   <script src="game.js"></script>


### PR DESCRIPTION
Implements the enhancements from #24 to make the game friendlier to first-time players and more accessible.\n\n**Changes**\n- Adds an in-page "How to Play" section near the Start Game controls with basic instructions (desktop + mobile).\n- Updates mobile touch controls to include accessible labels for assistive technologies.\n- Improves the orientation warning so it clearly instructs users to rotate to landscape and is only shown on mobile in portrait.\n- Relaxes the viewport / pinch-zoom restrictions so users can zoom when needed.\n\n**Notes**\n- Jest unit + e2e tests were run with `npm test`. At the moment there is one failing demonstration test in `tests/game.test.js` and a TypeScript parsing issue in `tests/e2e/bagit.spec.ts`; these pre-existing issues are unrelated to this change.\n\nFixes #24.