### PR TITLE
feat: WASD + continuous movement

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -389,18 +389,22 @@
     }
     /* Mobile touch controls */
     #mobileControls {
-      position: absolute;
-      bottom: 40px;
-      width: 100%;
+      position: fixed;
+      left: 0;
+      right: 0;
+      bottom: max(16px, env(safe-area-inset-bottom, 0px) + 12px);
       display: none;
-      justify-content: space-around;
-      z-index: 100;
+      justify-content: space-between;
+      padding: 0 24px;
+      z-index: 120;
       touch-action: manipulation;
+      pointer-events: none; /* let canvas receive touches except on buttons */
     }
     .controlButton {
+      flex: 0 0 auto;
       width: 80px;
       height: 80px;
-      background-color: rgba(255, 87, 34, 0.7);
+      background-color: rgba(255, 87, 34, 0.78);
       border-radius: 50%;
       display: flex;
       align-items: center;
@@ -413,12 +417,27 @@
       touch-action: manipulation;
       -webkit-appearance: none;
       -webkit-touch-callout: none;
+      box-shadow: 0 4px 14px rgba(0,0,0,0.35);
+      pointer-events: auto;
     }
-    @media (max-width: 480px) {
+    @media (max-width: 600px) {
+      #mobileControls {
+        padding: 0 16px;
+      }
       .controlButton {
-        width: 70px;
-        height: 70px;
+        width: 72px;
+        height: 72px;
         font-size: 24px;
+      }
+    }
+    @media (max-width: 400px) {
+      #mobileControls {
+        padding: 0 12px;
+      }
+      .controlButton {
+        width: 64px;
+        height: 64px;
+        font-size: 22px;
       }
     }
     @keyframes rotateStar {

--- a/game.js
+++ b/game.js
@@ -115,6 +115,10 @@
     let totalCatches = 0;
     let totalMisses = 0;
 
+    // Keyboard movement state (for smooth, continuous movement)
+    let movingLeft = false;
+    let movingRight = false;
+
     // Cat object declared BEFORE usage in resizeCanvas
     let cat = {
       x: canvas.width / 2,
@@ -201,14 +205,30 @@
     }, { passive: false });
 
     document.addEventListener('keydown', function (event) {
-      if (event.key === 'ArrowLeft') {
-        moveLeft();
-      } else if (event.key === 'ArrowRight') {
-        moveRight();
-      } else if (event.key === ' ' || event.key === 'ArrowUp') {
+      const key = event.key;
+
+      if (key === 'ArrowLeft' || key === 'a' || key === 'A') {
+        event.preventDefault();
+        movingLeft = true;
+      } else if (key === 'ArrowRight' || key === 'd' || key === 'D') {
+        event.preventDefault();
+        movingRight = true;
+      } else if (key === ' ' || key === 'ArrowUp' || key === 'w' || key === 'W') {
+        event.preventDefault();
         jump();
-      } else if (event.key === 'p' || event.key === 'P' || event.key === 'Escape') {
+      } else if (key === 'p' || key === 'P' || key === 'Escape') {
+        event.preventDefault();
         togglePause();
+      }
+    });
+
+    document.addEventListener('keyup', function (event) {
+      const key = event.key;
+
+      if (key === 'ArrowLeft' || key === 'a' || key === 'A') {
+        movingLeft = false;
+      } else if (key === 'ArrowRight' || key === 'd' || key === 'D') {
+        movingRight = false;
       }
     });
 
@@ -317,6 +337,12 @@
     }
 
     function updateCat() {
+      // Keyboard-driven horizontal movement (desktop only)
+      if (!isMobile && !isPaused) {
+        if (movingLeft) moveLeft();
+        if (movingRight) moveRight();
+      }
+
       // Magnet: pull nearby baguettes toward cat
       if (activePowerups['magnet']) {
         baguettes.forEach((b) => {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "testEnvironment": "jsdom",
     "setupFiles": [
       "./tests/setup.js"
+    ],
+    "testPathIgnorePatterns": [
+      "<rootDir>/tests/e2e"
     ]
   }
 }


### PR DESCRIPTION
Adds continuous keyboard movement using arrow keys and WASD, including W/space for jump. Also refines Jest config to ignore Playwright e2e specs during unit test runs and polishes mobile control layout.\n\nCloses #22.