### PR TITLE
feat: game over summary screen

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -172,21 +172,40 @@
       margin-top: 4px;
     }
     #endScoreSummary {
-      background: rgba(255,255,255,0.95);
-      border-radius: 12px;
-      padding: 16px 24px;
-      margin: 0 auto 16px auto;
-      max-width: 300px;
+      background: rgba(255,255,255,0.97);
+      border-radius: 16px;
+      padding: 18px 24px;
+      margin: 18px auto 16px auto;
+      max-width: 320px;
       text-align: center;
-      box-shadow: 0 4px 16px rgba(0,0,0,0.15);
+      box-shadow: 0 6px 24px rgba(0,0,0,0.25);
       font-size: 16px;
       color: #333;
+      animation: endSummaryPop 0.3s ease-out;
     }
     #endScoreSummary .new-record {
       color: #FF5722;
       font-weight: bold;
       font-size: 18px;
       margin-top: 6px;
+    }
+    @media (max-width: 480px) {
+      #endScoreSummary {
+        margin-top: 12px;
+        max-width: 90%;
+        padding: 14px 16px;
+        font-size: 15px;
+      }
+    }
+    @keyframes endSummaryPop {
+      0% {
+        transform: translateY(8px) scale(0.96);
+        opacity: 0;
+      }
+      100% {
+        transform: translateY(0) scale(1);
+        opacity: 1;
+      }
     }
     @media (max-width: 480px) {
       #startButton {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "testEnvironment": "jsdom",
     "setupFiles": [
       "./tests/setup.js"
+    ],
+    "testPathIgnorePatterns": [
+      "<rootDir>/tests/e2e"
     ]
   }
 }


### PR DESCRIPTION
Polishes the game over experience with a dedicated summary card (score, stars, difficulty, accuracy, personal best) and a clear Play Again button to start a new round without reloading the page. Also ensures Jest unit tests ignore Playwright e2e specs.\n\nCloses #20.