### PR TITLE
feat: add sound toggle

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -504,3 +504,25 @@
       display: none;
     }
   </style>
+
+    #soundToggleButton {
+      position: absolute;
+      top: 10px;
+      left: 180px;
+      padding: 6px 10px;
+      font-size: 16px;
+      cursor: pointer;
+      background-color: rgba(80,80,80,0.8);
+      color: white;
+      border: none;
+      border-radius: 999px;
+      z-index: 100;
+    }
+    @media (max-width: 480px) {
+      #soundToggleButton {
+        top: 40px;
+        left: 10px;
+        font-size: 14px;
+        padding: 4px 8px;
+      }
+    }

--- a/game.js
+++ b/game.js
@@ -14,6 +14,7 @@
     const scoreElement = document.getElementById('score');
     const starsElement = document.getElementById('stars');
     const catchSound = document.getElementById('catchSound');
+    const soundToggleButton = document.getElementById('soundToggleButton');
     const body = document.body;
     const mobileControls = document.getElementById('mobileControls');
     const leftButton = document.getElementById('leftButton');
@@ -35,6 +36,9 @@
         navigator.userAgent
       );
 
+    let isMuted = false;
+
+
     // Difficulty settings
     let selectedDifficulty = 'easy';
     const DIFFICULTY = {
@@ -53,6 +57,22 @@
       const pb = getPersonalBest(selectedDifficulty);
       personalBestEl.textContent = pb > 0 ? `🏅 Your best (${selectedDifficulty}): ${pb}` : '';
     }
+
+    function applyMuteState() {
+      catchSound.muted = isMuted;
+      if (soundToggleButton) {
+        soundToggleButton.textContent = isMuted ? '🔇' : '🔊';
+        soundToggleButton.setAttribute('aria-label', isMuted ? 'Unmute sound' : 'Mute sound');
+      }
+    }
+
+    try {
+      const stored = localStorage.getItem('bagit_sound_muted');
+      if (stored === 'true') {
+        isMuted = true;
+        applyMuteState();
+      }
+    } catch (e) {}
 
     // Wire up difficulty buttons
     document.querySelectorAll('.diffBtn').forEach(btn => {
@@ -203,6 +223,15 @@
 
     addTouchEventHandler(startButton, startGame);
     addTouchEventHandler(stopButton, stopGame);
+    if (soundToggleButton) {
+      soundToggleButton.addEventListener('click', function () {
+        isMuted = !isMuted;
+        try {
+          localStorage.setItem('bagit_sound_muted', String(isMuted));
+        } catch (e) {}
+        applyMuteState();
+      });
+    }
 
     canvas.addEventListener('click', jump);
     // On mobile, the dedicated jump button handles jumping.
@@ -1125,7 +1154,7 @@
         catchSound.play().then(() => {
           catchSound.pause();
           catchSound.currentTime = 0;
-          catchSound.muted = false;
+          catchSound.muted = isMuted;
         }).catch(() => {});
       } catch (err) {}
     }

--- a/index.html
+++ b/index.html
@@ -44,6 +44,7 @@
   <div id="leaderboard"></div>
   <button id="stopButton">Stop Game</button>
   <button id="pauseButton" style="display:none;">⏸ Pause</button>
+  <button id="soundToggleButton" aria-label="Toggle sound">🔊</button>
   <div id="scoreboard">
     Time: <span id="time">60</span>s | Score: <span id="score">0</span> | ⭐ <span id="stars">0</span>
   </div>


### PR DESCRIPTION
Adds a simple mute / unmute control so players can choose whether to hear game sounds.\n\n- New sound toggle button next to the pause / stop controls\n- Toggles the baguette catch sound on and off\n- Persists the mute choice in localStorage (per browser)\n- Respects the mute flag even after the iOS audio unlock shim runs\n\ncloses #6