### PR TITLE
feat: clean CSS and local asset usage

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,4 +1,3 @@
-<style>
     * {
       box-sizing: border-box;
       -webkit-tap-highlight-color: transparent;
@@ -14,7 +13,7 @@
       height: 100%;
     }
     body.start {
-      background: url('https://bagit.explorium.ninja/assets/background.png') no-repeat center center fixed;
+      background: url('../assets/background.png') no-repeat center center fixed;
       background-size: contain;
       background-position: center;
       background-color: black;
@@ -503,8 +502,6 @@
       z-index: 220;
       display: none;
     }
-  </style>
-
     #soundToggleButton {
       position: absolute;
       top: 10px;

--- a/game.js
+++ b/game.js
@@ -206,7 +206,7 @@
     window.addEventListener('orientationchange', resizeCanvas);
 
     const catImg = new Image();
-    catImg.src = 'https://bagit.explorium.ninja/assets/github.png';
+    catImg.src = 'assets/github.png';
 
     /**********************************************
      * 3) Helper for Both Touch & Click


### PR DESCRIPTION
Cleans up stylesheet and local asset references.\n\n- Removes stray <style> wrapper tags from css/style.css so it is a pure stylesheet.\n- Switches body.start background image to the local ../assets/background.png instead of the remote URL.\n- Points the in-game cat image to the local assets/github.png rather than the hosted version.\n\nThis addresses the CSS/asset clean-up requested in #25.