### PR TITLE
feat: refine HUD contrast and timer

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -32,15 +32,17 @@
       position: absolute;
       top: 10px;
       right: 10px;
-      font-size: 18px;
-      font-weight: bold;
-      color: #222;
+      font-size: 20px;
+      font-weight: 700;
+      letter-spacing: 0.03em;
+      color: #111;
       display: none;
-      background-color: rgba(255, 255, 255, 0.85);
-      padding: 6px 12px;
-      border-radius: 8px;
+      background: linear-gradient(135deg, rgba(255,255,255,0.98), rgba(255,245,235,0.96));
+      padding: 8px 14px;
+      border-radius: 999px;
       z-index: 100;
-      box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+      box-shadow: 0 3px 10px rgba(0,0,0,0.25);
+      border: 1px solid rgba(0,0,0,0.18);
     }
     #scoreboard .time-low {
       color: #d32f2f;
@@ -53,10 +55,13 @@
     }
     @media (max-width: 480px) {
       #scoreboard {
-        font-size: 13px;
-        top: 5px;
-        right: 5px;
-        padding: 3px 7px;
+        top: 6px;
+        right: 50%;
+        transform: translateX(50%);
+        font-size: 14px;
+        padding: 6px 12px;
+        max-width: 90vw;
+        text-align: center;
       }
     }
     #gameControls {

--- a/game.js
+++ b/game.js
@@ -495,7 +495,7 @@
             timerInterval = setInterval(() => {
               if (time > 0) {
                 time--;
-                timeElement.textContent = time;
+                updateTimeUI();
               } else if (!endGameTriggered) {
                 clearInterval(timerInterval);
                 endGame(currentNickname);


### PR DESCRIPTION
Improves scoreboard readability and low-time feedback.\n\n- Restyles the HUD scoreboard pill with higher contrast text, a subtle gradient, and a stronger drop shadow.\n- Centers the HUD on small screens and enlarges tap targets so time/score are easier to read on phones.\n- Wires the countdown timer to use updateTimeUI(), so the red flashing `time-low` state is driven from the live timer instead of only on start.\n\nThis closes #23.