### PR TITLE
feat: game over summary focus and replay

### DIFF
--- a/game.js
+++ b/game.js
@@ -1110,6 +1110,10 @@
 
       const playAgainButtonEl = document.getElementById('playAgainButton');
       if (playAgainButtonEl) {
+        // Move keyboard focus to the primary action so the summary feels like a proper end-of-round screen.
+        try {
+          playAgainButtonEl.focus();
+        } catch (e) {}
         playAgainButtonEl.addEventListener('click', function () {
           // Hide summary and immediately start a new round with the current nickname & difficulty
           endScoreSummary.style.display = 'none';


### PR DESCRIPTION
Small polish on the game over summary screen.\n\n- When the summary is shown, move keyboard focus to the "Play Again" button so players can restart quickly (and screen readers land on the primary action).\n- Keeps the existing rich summary (score, stars, difficulty label, accuracy, PB callout) visible before/while the leaderboard loads, matching the intent of #10.\n\nThis closes #10.