### PR TITLE
fix: keep difficulty buttons on one line on mobile

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -571,3 +571,14 @@
         white-space: nowrap;
       }
     }
+
+    /* Fine-tune difficulty layout for very narrow portrait phones */
+    @media (max-width: 420px) {
+      #difficultySelector {
+        max-width: 320px;
+      }
+      .diffBtn {
+        padding: 5px 6px;
+        font-size: 11px;
+      }
+    }


### PR DESCRIPTION
Ensures the Easy / Normal / Hard buttons stay on a single row even on narrow portrait screens (e.g. ~390px wide).\n\n- Tighten spacing and font size for difficulty buttons on very small widths\n- Cap the selector width so three buttons can shrink side-by-side without wrapping\n\nCloses #43.