### PR TITLE
v1.6.1 – make nickname optional for faster play

### DIFF
--- a/game.js
+++ b/game.js
@@ -464,11 +464,7 @@
     function startGame() {
       if (orientationWarning) orientationWarning.style.display = 'none';
 
-      const nickname = nicknameInput.value.trim();
-      if (!nickname) {
-        alert('Please enter your nickname!');
-        return;
-      }
+      const nickname = nicknameInput.value.trim() || nicknameInput.placeholder;
       currentNickname = nickname;
 
       body.classList.remove('start');

--- a/tests/game.test.js
+++ b/tests/game.test.js
@@ -34,16 +34,15 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 // 1. startGame() — refuses to start without a nickname
 // ---------------------------------------------------------------------------
-describe('startGame() — nickname validation', () => {
-  test('shows alert and does not hide gameControls when nickname is empty', () => {
-    const alertSpy = jest.spyOn(window, 'alert').mockImplementation(() => {});
+describe('startGame() — nickname handling', () => {
+  test('uses random placeholder when nickname is empty and proceeds', () => {
     const gameControls = document.getElementById('gameControls');
 
     document.getElementById('nicknameInput').value = '';
     document.getElementById('startButton').click();
 
-    expect(alertSpy).toHaveBeenCalledWith('Please enter your nickname!');
-    expect(gameControls.style.display).toBe('flex'); // start screen still visible
+    // Should proceed (no alert) — falls back to the random placeholder nickname
+    expect(gameControls.style.display).toBe('none');
   });
 
   test('proceeds (hides gameControls) when nickname is provided', () => {


### PR DESCRIPTION
## Summary

- Players can now hit **Start Game** immediately without typing a nickname
- If left empty, a random fun name from the placeholder list is used (BaguetteMaster, CroissantKing, etc.)
- Removes the blocking `alert('Please enter your nickname!')` — zero friction to start playing

## Test plan

- [x] `npm test` — all 14 tests pass
- [ ] Empty nickname → game starts with placeholder name shown on leaderboard
- [ ] Typed nickname → works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)